### PR TITLE
Check that the hashtable has any buckets before trying to dereference one 

### DIFF
--- a/src/lpm.c
+++ b/src/lpm.c
@@ -190,7 +190,12 @@ hashmap_lookup(lpm_hmap_t *hmap, const void *key, size_t len)
 {
 	const uint32_t hash = fnv1a_hash(key, len);
 	const unsigned i = hash & (hmap->hashsize - 1);
-	lpm_ent_t *entry = hmap->bucket[i];
+	lpm_ent_t *entry;
+
+	if (hmap->hashsize == 0) {
+		return NULL;
+	}
+	entry = hmap->bucket[i];
 
 	while (entry) {
 		if (entry->len == len && memcmp(entry->key, key, len) == 0) {
@@ -206,7 +211,12 @@ hashmap_remove(lpm_hmap_t *hmap, const void *key, size_t len)
 {
 	const uint32_t hash = fnv1a_hash(key, len);
 	const unsigned i = hash & (hmap->hashsize - 1);
-	lpm_ent_t *prev = NULL, *entry = hmap->bucket[i];
+	lpm_ent_t *prev = NULL, *entry;
+
+	if (hmap->hashsize == 0) {
+		return -1;
+	}
+	entry = hmap->bucket[i];
 
 	while (entry) {
 		if (entry->len == len && memcmp(entry->key, key, len) == 0) {

--- a/src/t_lpm.c
+++ b/src/t_lpm.c
@@ -243,12 +243,42 @@ ipv6_basic_test(void)
 	lpm_destroy(lpm);
 }
 
+static void
+removal_test(void)
+{
+	lpm_t *lpm;
+	uint32_t addr[4];
+	size_t len;
+	unsigned pref;
+	void *val;
+	int ret;
+
+	lpm = lpm_create();
+	assert(lpm != NULL);
+
+	lpm_strtobin("fd00::1/96", addr, &len, &pref);
+	ret = lpm_remove(lpm, addr, len, pref);
+	assert(ret == -1);
+
+	lpm_strtobin("ffff:ffff:ffff:ffff::/64", addr, &len, &pref);
+	ret = lpm_insert(lpm, addr, len, pref, NULL);
+	assert(ret == 0);
+
+	ret = lpm_remove(lpm, addr, len, pref);
+	assert(ret == 0);
+	ret = lpm_remove(lpm, addr, len, pref);
+	assert(ret == -1);
+
+	lpm_destroy(lpm);
+}
+
 int
 main(void)
 {
 	ipv4_basic_test();
 	ipv4_basic_random();
 	ipv6_basic_test();
+	removal_test();
 	puts("ok");
 	return 0;
 }


### PR DESCRIPTION
This fixes a possible invalid memory access in `lpm_remove`, in the case it is called with a prefix length that has never been added.

Two `hashmap_*` functions are affected, `hashmap_lookup` and `hashmap_remove`.
The check has been added to both functions, making all the `hashmap_*` functions safe to call on empty hashtables.

`lpm_lookup` has an invariant where only non-empty hashtables are passed to `hashmap_lookup`, however I still think this should be accounted for should other things need to use `hashmap_lookup` in the future.


The alternative is to defer emptiness checks to the callers of `hashmap_(lookup|remove)`, but this strikes me as odd from an API perspective.