### PR TITLE
Use new method of JNI header generation.

### DIFF
--- a/src/jni/Makefile
+++ b/src/jni/Makefile
@@ -31,19 +31,18 @@ JAR_LIB=	liblpm.jar
 
 JAR=		$(JAVA_HOME)/bin/jar
 JAVA=		$(JAVA_HOME)/bin/java
-JAVAH=		$(JAVA_HOME)/bin/javah
 JAVAC=		$(JAVA_HOME)/bin/javac
 
 %.o: %.c
 	$(CC) $(CFLAGS) -fPIC -c $<
 
 $(LIB).so: $(OBJS)
-	$(CC) $(LDFLAGS) -fPIC -shared -o $@ $(notdir $^)
+	$(CC) $(LDFLAGS) -fPIC -shared -o $@ $^
 
 org_netbsd_liblpm_LPM.o: org_netbsd_liblpm_LPM.h org_netbsd_liblpm_LPM.c
 
-org_netbsd_liblpm_LPM.h: org/netbsd/liblpm/LPM.class
-	$(JAVAH) -jni org.netbsd.liblpm.LPM
+org_netbsd_liblpm_LPM.h org/netbsd/liblpm/LPM.class: org/netbsd/liblpm/LPM.java
+	$(JAVAC) -h . $<
 
 %.class: %.java
 	$(JAVAC) $<


### PR DESCRIPTION
The `javah` header generation program is not available in Java SE 10 or later.
This functionality has been replaced with the `-h` option in `javac`, which was added in Java SE 8.

This has been tested with Java 8 and 11.


Note I also removed the `$(notdir ...)` macro call in the `$(LIB).so` target - it was stripping off the parent directory part of `../lpm.o` and causing a build failure. In GNU make, [this seems to be exactly what to expect](https://www.gnu.org/software/make/manual/html_node/File-Name-Functions.html), so I'm a bit confused as to why it was there.