### PR TITLE
fix: add only single java home to CFLAGS

### DIFF
--- a/src/jni/Makefile
+++ b/src/jni/Makefile
@@ -22,7 +22,7 @@ JAVA_HOME?=	/usr/lib/jvm/java/
 
 CFLAGS+=	-I.. -I$(JAVA_HOME)/include
 # Sadly, jni_md.h location is OS dependent
-CFLAGS+=	-I$(shell dirname $(shell find -L $(JAVA_HOME) -name jni_md.h))
+CFLAGS+=	-I$(shell dirname $(shell find -L $(JAVA_HOME) -name jni_md.h | head -1))
 
 OBJS=		org_netbsd_liblpm_LPM.o ../lpm.o
 LIB=		org_netbsd_liblpm_LPM


### PR DESCRIPTION
The command gives me two valid locations on macos:

```sh
$ dirname $(find -L $JAVA_HOME -name jni_md.h)
/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/include/darwin
/opt/homebrew/opt/openjdk@17/include
```

so I limited it to only one.